### PR TITLE
feat(catalog): add docset size and tarix

### DIFF
--- a/scripts/build-catalog.ts
+++ b/scripts/build-catalog.ts
@@ -3,6 +3,10 @@ import { processFeeds } from "./process-dash-feeds";
 import { processContrib } from "./process-contrib";
 import { processCheatsheets } from "./process-cheatsheets";
 import { fetchReleases } from "./fetch-releases";
+import { diffCatalog, fetchBaseline, type DiffableEntry } from "./catalog-diff";
+import { enrichMetadata } from "./probe-metadata";
+
+const DEFAULT_BASELINE_URL = "https://api.zealdocs.org/_api/v1/catalog.json";
 
 const { values } = parseArgs({
     args: Bun.argv.slice(2),
@@ -11,6 +15,8 @@ const { values } = parseArgs({
         blacklist: { type: "string", default: "blacklist.json" },
         "resource-dir": { type: "string" },
         "feed-dir": { type: "string" },
+        // Previously-deployed catalog used as a diff baseline. Pass "" to skip.
+        baseline: { type: "string", default: DEFAULT_BASELINE_URL },
     },
     allowPositionals: false,
 });
@@ -40,7 +46,49 @@ console.log("\nProcessing cheatsheets...");
 const cheatsheetEntries = await processCheatsheets({ resourceDir });
 console.log(`  ${cheatsheetEntries.length} cheatsheets fetched.`);
 
-// Build com.kapeli legacy merged catalog (official + suffixed contrib + suffixed cheatsheet)
+// Full catalog (3 individual sources flat-merged). These objects are enriched
+// in place below, before the legacy catalog copies them, so both outputs carry
+// the size/tarix metadata.
+const catalogEntries = [...officialEntries, ...contribEntries, ...cheatsheetEntries];
+
+// Diff against the previously-deployed catalog so unchanged docsets reuse their
+// metadata instead of being re-probed.
+let baseline: DiffableEntry[] = [];
+if (values.baseline) {
+    try {
+        baseline = await fetchBaseline(values.baseline);
+    } catch (err) {
+        console.warn(`\nWarning: baseline unavailable, probing all docsets: ${err}`);
+    }
+} else {
+    console.log("\nBaseline disabled; probing all docsets.");
+}
+
+const diff = diffCatalog(catalogEntries, baseline);
+console.log(
+    `\nCatalog diff: ${diff.unchanged.length} unchanged, ${diff.changed.length} changed, ` +
+        `${diff.added.length} added, ${diff.removed.length} removed`,
+);
+if (diff.changed.length) console.log(`  changed: ${diff.changed.join(", ")}`);
+if (diff.added.length) console.log(`  added: ${diff.added.join(", ")}`);
+if (diff.removed.length) console.log(`  removed: ${diff.removed.join(", ")}`);
+
+console.log("\nProbing download sizes and tarix availability...");
+let meta = { reused: 0, probed: 0, failed: 0, skipped: 0 };
+try {
+    meta = await enrichMetadata({ entries: catalogEntries, diff, baseline, manifest });
+} catch (err) {
+    console.warn(`  Warning: metadata probing failed: ${err}`);
+}
+console.log(
+    `  ${meta.reused} reused, ${meta.probed} probed, ${meta.failed} failed` +
+        (meta.skipped ? `, ${meta.skipped} skipped` : ""),
+);
+
+catalogEntries.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+
+// Legacy merged catalog (official + suffixed contrib + suffixed cheatsheet),
+// derived after enrichment so the copies inherit size/tarix.
 const legacyEntries = [
     ...officialEntries.map((e) => ({ ...e, sourceId: "com.kapeli" })),
     ...contribEntries.map((e) => ({
@@ -57,10 +105,6 @@ const legacyEntries = [
     })),
 ];
 legacyEntries.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
-
-// Build full catalog (3 individual sources flat-merged)
-const catalogEntries = [...officialEntries, ...contribEntries, ...cheatsheetEntries];
-catalogEntries.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
 
 console.log("\nFetching Zeal releases from GitHub...");
 let releases: Awaited<ReturnType<typeof fetchReleases>> = [];

--- a/scripts/catalog-diff.test.ts
+++ b/scripts/catalog-diff.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, mock } from "bun:test";
+
+let baselineJson: unknown = [];
+mock.module("./fetch-retry", () => ({
+    fetchWithRetry: async (_url: string): Promise<Response> => ({ json: async () => baselineJson }) as Response,
+}));
+
+import { entryKey, fingerprint, diffCatalog, fetchBaseline, type DiffableEntry } from "./catalog-diff";
+
+describe("entryKey", () => {
+    it("combines sourceId and name", () => {
+        expect(entryKey({ sourceId: "com.kapeli.dash", name: "Bash" })).toBe("com.kapeli.dash/Bash");
+    });
+
+    it("distinguishes same name across sources", () => {
+        const a = entryKey({ sourceId: "com.kapeli.dash", name: "Vim" });
+        const b = entryKey({ sourceId: "com.kapeli.cheatsheet", name: "Vim" });
+        expect(a).not.toBe(b);
+    });
+});
+
+describe("fingerprint", () => {
+    it("dash: changes with revision or version list", () => {
+        const base: DiffableEntry = { name: "Bash", sourceId: "com.kapeli.dash", revision: "9", versions: ["9"] };
+        expect(fingerprint(base)).toBe(fingerprint({ ...base }));
+        expect(fingerprint({ ...base, revision: "10" })).not.toBe(fingerprint(base));
+        expect(fingerprint({ ...base, versions: ["9", "8"] })).not.toBe(fingerprint(base));
+    });
+
+    it("contrib: changes with archive or specific versions", () => {
+        const base: DiffableEntry = {
+            name: "Jest",
+            sourceId: "com.kapeli.contrib",
+            versions: ["29.0"],
+            archive: "Jest.tgz",
+            specificVersions: { "29.0": "versions/29.0/Jest.tgz" },
+        };
+        expect(fingerprint(base)).toBe(fingerprint({ ...base }));
+        expect(fingerprint({ ...base, archive: "Jest-new.tgz" })).not.toBe(fingerprint(base));
+        expect(fingerprint({ ...base, specificVersions: { "29.0": "x", "28.0": "y" } })).not.toBe(fingerprint(base));
+    });
+
+    it("contrib: specific-version order does not matter", () => {
+        const a: DiffableEntry = {
+            name: "Jest",
+            sourceId: "com.kapeli.contrib",
+            versions: ["29.0"],
+            archive: "Jest.tgz",
+            specificVersions: { "29.0": "a", "28.0": "b" },
+        };
+        const b: DiffableEntry = { ...a, specificVersions: { "28.0": "b", "29.0": "a" } };
+        expect(fingerprint(a)).toBe(fingerprint(b));
+    });
+
+    it("contrib: changes when a specific-version archive path changes", () => {
+        const a: DiffableEntry = {
+            name: "Jest",
+            sourceId: "com.kapeli.contrib",
+            versions: ["29.0"],
+            archive: "Jest.tgz",
+            specificVersions: { "29.0": "versions/29.0/Jest.tgz" },
+        };
+        const b: DiffableEntry = { ...a, specificVersions: { "29.0": "versions/29.0/Jest-v2.tgz" } };
+        expect(fingerprint(a)).not.toBe(fingerprint(b));
+    });
+
+    it("cheatsheet: changes only with version", () => {
+        const base: DiffableEntry = { name: "Vim", sourceId: "com.kapeli.cheatsheet", versions: ["1"] };
+        expect(fingerprint(base)).toBe(fingerprint({ ...base }));
+        expect(fingerprint({ ...base, versions: ["2"] })).not.toBe(fingerprint(base));
+    });
+});
+
+describe("diffCatalog", () => {
+    const baseline: DiffableEntry[] = [
+        { name: "Bash", sourceId: "com.kapeli.dash", revision: "9", versions: ["9"] },
+        { name: "Go", sourceId: "com.kapeli.dash", revision: "1", versions: ["1.26"] },
+        { name: "Vim", sourceId: "com.kapeli.cheatsheet", versions: ["1"] },
+    ];
+
+    it("classifies unchanged, changed, added, removed", () => {
+        const current: DiffableEntry[] = [
+            { name: "Bash", sourceId: "com.kapeli.dash", revision: "9", versions: ["9"] }, // unchanged
+            { name: "Go", sourceId: "com.kapeli.dash", revision: "2", versions: ["1.27"] }, // changed
+            { name: "Rust", sourceId: "com.kapeli.dash", revision: "1", versions: ["1.0"] }, // added
+            // Vim cheatsheet dropped -> removed
+        ];
+        const diff = diffCatalog(current, baseline);
+        expect(diff.unchanged).toEqual(["com.kapeli.dash/Bash"]);
+        expect(diff.changed).toEqual(["com.kapeli.dash/Go"]);
+        expect(diff.added).toEqual(["com.kapeli.dash/Rust"]);
+        expect(diff.removed).toEqual(["com.kapeli.cheatsheet/Vim"]);
+    });
+
+    it("treats an empty baseline as all-added", () => {
+        const diff = diffCatalog(baseline, []);
+        expect(diff.added).toHaveLength(3);
+        expect(diff.unchanged).toHaveLength(0);
+        expect(diff.changed).toHaveLength(0);
+        expect(diff.removed).toHaveLength(0);
+    });
+});
+
+describe("fetchBaseline", () => {
+    it("drops malformed entries missing name or sourceId", async () => {
+        baselineJson = [
+            { name: "Bash", sourceId: "com.kapeli.dash" },
+            { name: "NoSource" },
+            { sourceId: "com.kapeli.dash" },
+            null,
+        ];
+        const entries = await fetchBaseline("https://example/catalog.json");
+        expect(entries).toEqual([{ name: "Bash", sourceId: "com.kapeli.dash" }]);
+    });
+
+    it("throws when the payload is not an array", async () => {
+        baselineJson = { not: "an array" };
+        await expect(fetchBaseline("https://example/catalog.json")).rejects.toThrow();
+    });
+});

--- a/scripts/catalog-diff.ts
+++ b/scripts/catalog-diff.ts
@@ -1,0 +1,100 @@
+import { fetchWithRetry } from "./fetch-retry";
+
+/**
+ * Minimal shape needed to diff a docset entry. Both freshly-built entries and
+ * baseline entries parsed from the live catalog.json satisfy this.
+ */
+export type DiffableEntry = {
+    name: string;
+    sourceId: string;
+    revision?: string;
+    versions?: string[];
+    archive?: string;
+    specificVersions?: Record<string, string>;
+    size?: number;
+    tarix?: boolean;
+};
+
+export function entryKey(e: { sourceId: string; name: string }): string {
+    return `${e.sourceId}/${e.name}`;
+}
+
+/**
+ * A fingerprint derived from each source's version/revision signal, used to
+ * detect which docsets changed between builds. It catches version/revision
+ * changes but not a tarball repacked in place under an unchanged version, so
+ * metadata reused on a fingerprint match (e.g. size) is best-effort, not exact.
+ */
+export function fingerprint(e: DiffableEntry): string {
+    const versions = (Array.isArray(e.versions) ? e.versions : []).join(",");
+    switch (e.sourceId) {
+        case "com.kapeli.dash":
+            return `${e.revision ?? "0"}|${versions}`;
+        case "com.kapeli.contrib": {
+            const specific = Object.entries(e.specificVersions ?? {})
+                .sort(([a], [b]) => a.localeCompare(b))
+                .map(([version, archivePath]) => `${version}:${archivePath}`)
+                .join(",");
+            return `${versions}|${e.archive ?? ""}|${specific}`;
+        }
+        case "com.kapeli.cheatsheet":
+            // Cheatsheet download URLs are unversioned; version is the only signal.
+            return versions;
+        default:
+            // Unknown source: fold in every field so any change is caught.
+            return `${e.revision ?? "0"}|${versions}|${e.archive ?? ""}`;
+    }
+}
+
+// Values are entryKey() strings; added/removed are relative to the baseline.
+export type CatalogDiff = {
+    unchanged: string[];
+    changed: string[];
+    added: string[];
+    removed: string[];
+};
+
+export function diffCatalog(current: DiffableEntry[], baseline: DiffableEntry[]): CatalogDiff {
+    const baseMap = new Map(baseline.map((e) => [entryKey(e), e]));
+    const currentKeys = new Set<string>();
+    const diff: CatalogDiff = { unchanged: [], changed: [], added: [], removed: [] };
+
+    for (const entry of current) {
+        const key = entryKey(entry);
+        currentKeys.add(key);
+        const base = baseMap.get(key);
+        if (!base) {
+            diff.added.push(key);
+        } else if (fingerprint(entry) === fingerprint(base)) {
+            diff.unchanged.push(key);
+        } else {
+            diff.changed.push(key);
+        }
+    }
+
+    for (const key of baseMap.keys()) {
+        if (!currentKeys.has(key)) diff.removed.push(key);
+    }
+
+    return diff;
+}
+
+/** Fetch and parse the previously-deployed catalog as a diff baseline. */
+export async function fetchBaseline(url: string): Promise<DiffableEntry[]> {
+    const res = await fetchWithRetry(url);
+    const data = await res.json();
+    if (!Array.isArray(data)) {
+        throw new Error("Baseline catalog is not a JSON array");
+    }
+    return (data as DiffableEntry[]).flatMap((e) => {
+        if (!e || typeof e.name !== "string" || typeof e.sourceId !== "string") return [];
+        // `size`/`tarix` are reused verbatim into output, so reject bad types.
+        return [
+            {
+                ...e,
+                size: typeof e.size === "number" && Number.isFinite(e.size) && e.size >= 0 ? e.size : undefined,
+                tarix: typeof e.tarix === "boolean" ? e.tarix : undefined,
+            },
+        ];
+    });
+}

--- a/scripts/probe-metadata.test.ts
+++ b/scripts/probe-metadata.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { enrichMetadata, archiveUrl, type EnrichableEntry } from "./probe-metadata";
+import type { CatalogDiff } from "./catalog-diff";
+
+const MIRROR = "m.test";
+const manifest = { Go: {} };
+
+const realFetch = globalThis.fetch;
+let responses: Map<string, { status: number; len?: string }>;
+let throwUrls: Set<string>;
+let fetched: string[];
+
+beforeEach(() => {
+    responses = new Map();
+    throwUrls = new Set();
+    fetched = [];
+    globalThis.fetch = (async (url: string | URL | Request) => {
+        const u = String(url);
+        fetched.push(u);
+        if (throwUrls.has(u)) throw new Error("network");
+        const r = responses.get(u);
+        const headers = new Headers();
+        if (r?.len !== undefined) headers.set("content-length", r.len);
+        return { status: r?.status ?? 404, headers } as Response;
+    }) as typeof fetch;
+});
+
+afterEach(() => {
+    globalThis.fetch = realFetch;
+});
+
+const emptyDiff = (): CatalogDiff => ({ unchanged: [], changed: [], added: [], removed: [] });
+
+describe("archiveUrl", () => {
+    it("builds per-source URLs and rejects unknown sources", () => {
+        expect(archiveUrl({ name: "Go", sourceId: "com.kapeli.dash", versions: ["1.0"] }, MIRROR, manifest)).toBe(
+            "https://m.test/feeds/zzz/versions/Go/1.0/Go.tgz",
+        );
+        expect(
+            archiveUrl({ name: "Jest", sourceId: "com.kapeli.contrib", archive: "Jest.tgz" }, MIRROR, manifest),
+        ).toBe("https://m.test/feeds/zzz/user_contributed/build/Jest/Jest.tgz");
+        expect(archiveUrl({ name: "Vim", sourceId: "com.kapeli.cheatsheet" }, MIRROR, manifest)).toBe(
+            "https://m.test/feeds/zzz/cheatsheets/Vim.tgz",
+        );
+        expect(archiveUrl({ name: "X", sourceId: "other" }, MIRROR, manifest)).toBeNull();
+    });
+});
+
+describe("enrichMetadata", () => {
+    it("reuses baseline metadata for unchanged entries without probing", async () => {
+        const entries: EnrichableEntry[] = [{ name: "Go", sourceId: "com.kapeli.dash", versions: ["1.0"] }];
+        const diff = { ...emptyDiff(), unchanged: ["com.kapeli.dash/Go"] };
+        const baseline = [{ name: "Go", sourceId: "com.kapeli.dash", size: 999, tarix: true }];
+
+        const stats = await enrichMetadata({ entries, diff, baseline, manifest, mirror: MIRROR });
+
+        expect(entries[0].size).toBe(999);
+        expect(entries[0].tarix).toBe(true);
+        expect(stats).toEqual({ reused: 1, probed: 0, failed: 0, skipped: 0 });
+        expect(fetched).toHaveLength(0);
+    });
+
+    it("probes changed entries; size = archive + tarix when tarix exists", async () => {
+        responses.set("https://m.test/feeds/zzz/versions/Go/1.0/Go.tgz", { status: 200, len: "1000" });
+        responses.set("https://m.test/feeds/zzz/versions/Go/1.0/Go.tgz.tarix", { status: 200, len: "50" });
+        const entries: EnrichableEntry[] = [{ name: "Go", sourceId: "com.kapeli.dash", versions: ["1.0"] }];
+        const diff = { ...emptyDiff(), changed: ["com.kapeli.dash/Go"] };
+
+        const stats = await enrichMetadata({ entries, diff, baseline: [], manifest, mirror: MIRROR });
+
+        expect(entries[0].size).toBe(1050);
+        expect(entries[0].tarix).toBe(true);
+        expect(stats).toEqual({ reused: 0, probed: 1, failed: 0, skipped: 0 });
+    });
+
+    it("dash docset without a tarix index records tarix=false, size=archive", async () => {
+        responses.set("https://m.test/feeds/zzz/versions/Go/1.0/Go.tgz", { status: 200, len: "1000" });
+        responses.set("https://m.test/feeds/zzz/versions/Go/1.0/Go.tgz.tarix", { status: 302 });
+        const entries: EnrichableEntry[] = [{ name: "Go", sourceId: "com.kapeli.dash", versions: ["1.0"] }];
+        const diff = { ...emptyDiff(), changed: ["com.kapeli.dash/Go"] };
+
+        await enrichMetadata({ entries, diff, baseline: [], manifest, mirror: MIRROR });
+
+        expect(entries[0].size).toBe(1000);
+        expect(entries[0].tarix).toBe(false);
+    });
+
+    it("skips the tarix probe entirely for cheatsheets (source config)", async () => {
+        responses.set("https://m.test/feeds/zzz/cheatsheets/Vim.tgz", { status: 200, len: "500" });
+        const entries: EnrichableEntry[] = [{ name: "Vim", sourceId: "com.kapeli.cheatsheet" }];
+        const diff = { ...emptyDiff(), added: ["com.kapeli.cheatsheet/Vim"] };
+
+        const stats = await enrichMetadata({ entries, diff, baseline: [], manifest, mirror: MIRROR });
+
+        expect(entries[0].size).toBe(500);
+        expect(entries[0].tarix).toBe(false);
+        expect(stats.probed).toBe(1);
+        // Only the archive was fetched; the .tarix URL was never requested.
+        expect(fetched).toEqual(["https://m.test/feeds/zzz/cheatsheets/Vim.tgz"]);
+    });
+
+    it("leaves fields unset and counts failure when the archive is unreachable", async () => {
+        const entries: EnrichableEntry[] = [{ name: "Go", sourceId: "com.kapeli.dash", versions: ["1.0"] }];
+        const diff = { ...emptyDiff(), changed: ["com.kapeli.dash/Go"] };
+
+        const stats = await enrichMetadata({ entries, diff, baseline: [], manifest, mirror: MIRROR });
+
+        expect(entries[0].size).toBeUndefined();
+        expect(entries[0].tarix).toBeUndefined();
+        expect(stats).toEqual({ reused: 0, probed: 0, failed: 1, skipped: 0 });
+    });
+
+    it("treats a 429 on the archive as transient (not a definitive absence)", async () => {
+        responses.set("https://m.test/feeds/zzz/versions/Go/1.0/Go.tgz", { status: 429 });
+        const entries: EnrichableEntry[] = [{ name: "Go", sourceId: "com.kapeli.dash", versions: ["1.0"] }];
+        const diff = { ...emptyDiff(), changed: ["com.kapeli.dash/Go"] };
+
+        const stats = await enrichMetadata({ entries, diff, baseline: [], manifest, mirror: MIRROR, timeoutMs: 50 });
+
+        // Retried then gave up -> unset (re-probe next build), never recorded as size 0 / tarix false.
+        expect(entries[0].size).toBeUndefined();
+        expect(entries[0].tarix).toBeUndefined();
+        expect(stats.failed).toBe(1);
+    });
+
+    it("leaves fields unset when the tarix probe errors (so it re-probes next build)", async () => {
+        responses.set("https://m.test/feeds/zzz/versions/Go/1.0/Go.tgz", { status: 200, len: "1000" });
+        throwUrls.add("https://m.test/feeds/zzz/versions/Go/1.0/Go.tgz.tarix");
+        const entries: EnrichableEntry[] = [{ name: "Go", sourceId: "com.kapeli.dash", versions: ["1.0"] }];
+        const diff = { ...emptyDiff(), changed: ["com.kapeli.dash/Go"] };
+
+        const stats = await enrichMetadata({ entries, diff, baseline: [], manifest, mirror: MIRROR, timeoutMs: 50 });
+
+        expect(entries[0].size).toBeUndefined();
+        expect(entries[0].tarix).toBeUndefined();
+        expect(stats.failed).toBe(1);
+    });
+
+    it("counts entries with no resolvable URL as skipped, not failed", async () => {
+        const entries: EnrichableEntry[] = [{ name: "X", sourceId: "other" }];
+        const diff = { ...emptyDiff(), added: ["other/X"] };
+
+        const stats = await enrichMetadata({ entries, diff, baseline: [], manifest, mirror: MIRROR });
+
+        expect(stats).toEqual({ reused: 0, probed: 0, failed: 0, skipped: 1 });
+        expect(fetched).toHaveLength(0);
+    });
+
+    it("probes when marked unchanged but baseline lacks metadata (first run)", async () => {
+        responses.set("https://m.test/feeds/zzz/versions/Go/1.0/Go.tgz", { status: 200, len: "1000" });
+        responses.set("https://m.test/feeds/zzz/versions/Go/1.0/Go.tgz.tarix", { status: 200, len: "50" });
+        const entries: EnrichableEntry[] = [{ name: "Go", sourceId: "com.kapeli.dash", versions: ["1.0"] }];
+        const diff = { ...emptyDiff(), unchanged: ["com.kapeli.dash/Go"] };
+        const baseline = [{ name: "Go", sourceId: "com.kapeli.dash" }]; // no size/tarix
+
+        const stats = await enrichMetadata({ entries, diff, baseline, manifest, mirror: MIRROR });
+
+        expect(entries[0].size).toBe(1050);
+        expect(stats.probed).toBe(1);
+    });
+
+    it("processes every entry when there are more entries than the concurrency limit", async () => {
+        const entries: EnrichableEntry[] = [];
+        const added: string[] = [];
+        for (let i = 0; i < 40; i++) {
+            const name = `Sheet${i}`;
+            responses.set(`https://m.test/feeds/zzz/cheatsheets/${name}.tgz`, { status: 200, len: "100" });
+            entries.push({ name, sourceId: "com.kapeli.cheatsheet" });
+            added.push(`com.kapeli.cheatsheet/${name}`);
+        }
+        const diff = { ...emptyDiff(), added };
+
+        const stats = await enrichMetadata({ entries, diff, baseline: [], manifest, mirror: MIRROR, concurrency: 4 });
+
+        expect(stats.probed).toBe(40);
+        expect(entries.every((e) => e.size === 100 && e.tarix === false)).toBe(true);
+    });
+});

--- a/scripts/probe-metadata.ts
+++ b/scripts/probe-metadata.ts
@@ -1,0 +1,163 @@
+import { defaultMirror } from "../src/geo";
+import {
+    dashFeedName,
+    dashArchiveUrl,
+    contribArchiveUrl,
+    cheatsheetArchiveUrl,
+    tarixUrl,
+    type DocsetManifest,
+} from "../src/mirror-url";
+import { sourceHasTarix } from "../src/sources";
+import { entryKey, type CatalogDiff, type DiffableEntry } from "./catalog-diff";
+
+export type EnrichableEntry = {
+    name: string;
+    sourceId: string;
+    versions?: string[];
+    archive?: string;
+    size?: number;
+    tarix?: boolean;
+};
+
+/** Mirror URL of the archive a `/d/<source>/<name>/latest` request resolves to. */
+export function archiveUrl(entry: EnrichableEntry, mirror: string, manifest: DocsetManifest): string | null {
+    switch (entry.sourceId) {
+        case "com.kapeli.dash": {
+            const feedName = dashFeedName(entry.name, manifest);
+            return feedName ? dashArchiveUrl(feedName, entry.versions?.[0], mirror) : null;
+        }
+        case "com.kapeli.contrib":
+            return entry.archive ? contribArchiveUrl(entry.name, entry.archive, mirror) : null;
+        case "com.kapeli.cheatsheet":
+            return cheatsheetArchiveUrl(entry.name, mirror);
+        default:
+            return null;
+    }
+}
+
+/**
+ * Result of a HEAD probe:
+ * - `ok`     — a direct 200; `size` is the Content-Length (null if unreadable).
+ * - `absent` — a definitive 3xx/4xx (the mirror 302-redirects missing files).
+ * - `error`  — network failure or transient 5xx after retries; outcome unknown.
+ *
+ * The absent/error split matters: `absent` is a real "no such file" answer we
+ * can record, while `error` must leave the field unset so the next build
+ * re-probes instead of baking in a wrong value.
+ */
+type HeadResult = { kind: "ok"; size: number | null } | { kind: "absent" } | { kind: "error" };
+
+/**
+ * HEAD a URL with retry on transient failures. Identity encoding is requested
+ * so text files (the tarix index) report their real size instead of a
+ * compressed transfer length.
+ */
+async function head(url: string, timeoutMs: number, retries = 2): Promise<HeadResult> {
+    for (let attempt = 0; ; attempt++) {
+        try {
+            const res = await fetch(url, {
+                method: "HEAD",
+                redirect: "manual",
+                headers: { "Accept-Encoding": "identity" },
+                signal: AbortSignal.timeout(timeoutMs),
+            });
+            if (res.status === 200) {
+                const len = res.headers.get("content-length");
+                const n = len ? Number.parseInt(len, 10) : Number.NaN;
+                return { kind: "ok", size: Number.isFinite(n) ? n : null };
+            }
+            // 5xx and transient client statuses (timeout / too-early / rate-limit)
+            // are retried; any other 3xx/4xx is a definitive "not here".
+            const transient = res.status >= 500 || res.status === 408 || res.status === 425 || res.status === 429;
+            if (!transient) return { kind: "absent" };
+        } catch {
+            // Network error / timeout: retry.
+        }
+        if (attempt >= retries) return { kind: "error" };
+        await Bun.sleep(500);
+    }
+}
+
+async function runPool<T>(items: T[], limit: number, fn: (item: T) => Promise<void>): Promise<void> {
+    let next = 0;
+    const worker = async () => {
+        while (next < items.length) {
+            await fn(items[next++]);
+        }
+    };
+    await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+}
+
+/**
+ * Populate `size` (download bytes; archive + tarix index when present) and
+ * `tarix` on each entry. Entries unchanged since the baseline reuse its
+ * metadata; the rest are probed with HEAD requests. Probe failures leave the
+ * fields unset so "unknown" stays distinct from a real value.
+ */
+export async function enrichMetadata(options: {
+    entries: EnrichableEntry[];
+    diff: CatalogDiff;
+    baseline: DiffableEntry[];
+    manifest: DocsetManifest;
+    mirror?: string;
+    concurrency?: number;
+    timeoutMs?: number;
+}): Promise<{ reused: number; probed: number; failed: number; skipped: number }> {
+    const { entries, diff, baseline, manifest, mirror = defaultMirror, concurrency = 16, timeoutMs = 10_000 } = options;
+
+    const reusable = new Set(diff.unchanged);
+    const baseMeta = new Map(baseline.map((b) => [entryKey(b), b]));
+
+    const toProbe: EnrichableEntry[] = [];
+    let reused = 0;
+    for (const entry of entries) {
+        const base = reusable.has(entryKey(entry)) ? baseMeta.get(entryKey(entry)) : undefined;
+        if (base && base.size !== undefined && base.tarix !== undefined) {
+            entry.size = base.size;
+            entry.tarix = base.tarix;
+            reused++;
+        } else {
+            toProbe.push(entry);
+        }
+    }
+
+    let probed = 0;
+    let failed = 0;
+    let skipped = 0;
+    await runPool(toProbe, concurrency, async (entry) => {
+        try {
+            const url = archiveUrl(entry, mirror, manifest);
+            if (url === null) {
+                skipped++;
+                return;
+            }
+            const archive = await head(url, timeoutMs);
+            if (archive.kind !== "ok" || archive.size === null) {
+                failed++;
+                return;
+            }
+
+            // Sources known to lack tarix indices: record false without a probe.
+            if (!sourceHasTarix(entry.sourceId)) {
+                entry.size = archive.size;
+                entry.tarix = false;
+                probed++;
+                return;
+            }
+
+            const tarix = await head(tarixUrl(url), timeoutMs);
+            if (tarix.kind === "error") {
+                // Unknown tarix state: leave unset so the next build re-probes.
+                failed++;
+                return;
+            }
+            entry.size = archive.size + (tarix.kind === "ok" ? (tarix.size ?? 0) : 0);
+            entry.tarix = tarix.kind === "ok";
+            probed++;
+        } catch {
+            failed++;
+        }
+    });
+
+    return { reused, probed, failed, skipped };
+}

--- a/scripts/process-cheatsheets.ts
+++ b/scripts/process-cheatsheets.ts
@@ -11,6 +11,8 @@ export type CheatsheetDocsetInfo = {
     versions: string[];
     icon: string;
     icon2x: string;
+    size?: number;
+    tarix?: boolean;
 };
 
 type CheatsheetApiEntry = {

--- a/scripts/process-contrib.ts
+++ b/scripts/process-contrib.ts
@@ -12,6 +12,8 @@ export type ContribDocsetInfo = {
     icon2x: string;
     archive: string;
     specificVersions: Record<string, string>;
+    size?: number;
+    tarix?: boolean;
 };
 
 type ContribApiEntry = {

--- a/scripts/process-dash-feeds.ts
+++ b/scripts/process-dash-feeds.ts
@@ -23,6 +23,8 @@ export type DocsetInfo = {
     icon: string;
     icon2x: string;
     extra?: Record<string, unknown>;
+    size?: number;
+    tarix?: boolean;
 };
 
 function parseVersionList(entry: Record<string, unknown>): {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { getMirror } from "./geo";
+import { dashFeedName, dashArchiveUrl, contribArchiveUrl, cheatsheetArchiveUrl } from "./mirror-url";
 import { linkMap } from "./links";
 import { track } from "./track";
 import docsets from "../docsets.json";
@@ -69,21 +70,21 @@ export function createApp(
         firstVersion: Map<string, string>,
         mirror: string,
     ): string | null {
-        if (!Object.hasOwn(manifest, docsetId)) return null;
-        const feedName = manifest[docsetId].source ?? docsetId;
+        const feedName = dashFeedName(docsetId, manifest);
+        if (!feedName) return null;
         const resolvedVersion = version === "latest" ? firstVersion.get(docsetId) : version;
-        return resolvedVersion
-            ? `https://${mirror}/feeds/zzz/versions/${feedName}/${resolvedVersion}/${feedName}.tgz`
-            : `https://${mirror}/feeds/${feedName}.tgz`;
+        return dashArchiveUrl(feedName, resolvedVersion, mirror);
     }
 
     return (
         new Elysia()
             .get("/", ({ redirect }) => redirect("https://zealdocs.org", 302))
-            .get("/robots.txt", () =>
-                new Response("User-agent: *\nDisallow: /\n", {
-                    headers: { "content-type": "text/plain", "cache-control": "public, max-age=86400" },
-                }),
+            .get(
+                "/robots.txt",
+                () =>
+                    new Response("User-agent: *\nDisallow: /\n", {
+                        headers: { "content-type": "text/plain", "cache-control": "public, max-age=86400" },
+                    }),
             )
             .get("/favicon.ico", () => new Response(null, { status: 204 }))
             .get("/v1/releases", ({ request }) => {
@@ -145,7 +146,7 @@ export function createApp(
                             return "Not found";
                         }
                         trackDownload("com.kapeli.cheatsheet", key);
-                        return redirect(`https://${mirror}/feeds/zzz/cheatsheets/${key}.tgz`, 302);
+                        return redirect(cheatsheetArchiveUrl(key, mirror), 302);
                     }
 
                     if (docsetId.endsWith("_Contrib")) {
@@ -160,7 +161,7 @@ export function createApp(
                                 ? entry.specificVersions[version]
                                 : entry.archive;
                         trackDownload("com.kapeli.contrib", key);
-                        return redirect(`https://${mirror}/feeds/zzz/user_contributed/build/${key}/${archive}`, 302);
+                        return redirect(contribArchiveUrl(key, archive, mirror), 302);
                     }
 
                     // Official Dash docset

--- a/src/mirror-url.test.ts
+++ b/src/mirror-url.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "bun:test";
+import { dashFeedName, dashArchiveUrl, contribArchiveUrl, cheatsheetArchiveUrl, tarixUrl } from "./mirror-url";
+
+const M = "frankfurt.kapeli.com";
+
+describe("dashFeedName", () => {
+    const manifest = { Go: {}, Python_3: { source: "Python" } };
+
+    it("returns the docset id when no source override", () => {
+        expect(dashFeedName("Go", manifest)).toBe("Go");
+    });
+
+    it("returns the source override when present", () => {
+        expect(dashFeedName("Python_3", manifest)).toBe("Python");
+    });
+
+    it("returns null for unknown docsets", () => {
+        expect(dashFeedName("Nope", manifest)).toBeNull();
+    });
+});
+
+describe("dashArchiveUrl", () => {
+    it("uses the versioned path when a version is given", () => {
+        expect(dashArchiveUrl("Go", "1.26.1", M)).toBe(
+            "https://frankfurt.kapeli.com/feeds/zzz/versions/Go/1.26.1/Go.tgz",
+        );
+    });
+
+    it("uses the feed root when no version", () => {
+        expect(dashArchiveUrl("Bash", undefined, M)).toBe("https://frankfurt.kapeli.com/feeds/Bash.tgz");
+    });
+});
+
+describe("contrib/cheatsheet/tarix URLs", () => {
+    it("builds the contrib path with key and archive", () => {
+        expect(contribArchiveUrl("Jest", "Jest.tgz", M)).toBe(
+            "https://frankfurt.kapeli.com/feeds/zzz/user_contributed/build/Jest/Jest.tgz",
+        );
+    });
+
+    it("builds the cheatsheet path", () => {
+        expect(cheatsheetArchiveUrl("Vim", M)).toBe("https://frankfurt.kapeli.com/feeds/zzz/cheatsheets/Vim.tgz");
+    });
+
+    it("appends .tarix to any archive url", () => {
+        expect(tarixUrl("https://x/y.tgz")).toBe("https://x/y.tgz.tarix");
+    });
+});

--- a/src/mirror-url.ts
+++ b/src/mirror-url.ts
@@ -1,0 +1,29 @@
+export type DocsetManifest = Record<string, { source?: string }>;
+
+/** Feed file base name for a Dash docset, or null if the docset is unknown. */
+export function dashFeedName(docsetId: string, manifest: DocsetManifest): string | null {
+    return Object.hasOwn(manifest, docsetId) ? (manifest[docsetId].source ?? docsetId) : null;
+}
+
+/**
+ * Mirror URL for a Dash docset archive. Versioned docsets live under a
+ * per-version path; those without a version are served from the feed root.
+ */
+export function dashArchiveUrl(feedName: string, version: string | undefined, mirror: string): string {
+    return version
+        ? `https://${mirror}/feeds/zzz/versions/${feedName}/${version}/${feedName}.tgz`
+        : `https://${mirror}/feeds/${feedName}.tgz`;
+}
+
+export function contribArchiveUrl(key: string, archive: string, mirror: string): string {
+    return `https://${mirror}/feeds/zzz/user_contributed/build/${key}/${archive}`;
+}
+
+export function cheatsheetArchiveUrl(key: string, mirror: string): string {
+    return `https://${mirror}/feeds/zzz/cheatsheets/${key}.tgz`;
+}
+
+/** The tarix index is served alongside its archive at the same path plus `.tarix`. */
+export function tarixUrl(archiveUrl: string): string {
+    return `${archiveUrl}.tarix`;
+}

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -1,0 +1,15 @@
+export type SourceConfig = {
+    /** Whether docsets from this source ship a tarix index alongside the archive. */
+    hasTarix: boolean;
+};
+
+export const SOURCES: Record<string, SourceConfig> = {
+    "com.kapeli.dash": { hasTarix: true },
+    "com.kapeli.contrib": { hasTarix: true },
+    "com.kapeli.cheatsheet": { hasTarix: false },
+};
+
+/** Defaults to true for unknown sources so they are still probed rather than assumed tarix-less. */
+export function sourceHasTarix(sourceId: string): boolean {
+    return SOURCES[sourceId]?.hasTarix ?? true;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Catalog baseline diffing with optional baseline URL and resilient fallback handling.
  * Metadata enrichment that probes archives to record sizes and index availability, honoring concurrency and retries.
  * Source index support detection and mirror-aware redirect URL generation.

* **Tests**
  * Added thorough tests for catalog diffing, baseline fetching, metadata probing, and mirror URL builders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->