### PR TITLE
fix(api): bare-path fallback for latest redirect

### DIFF
--- a/scripts/catalog-diff.ts
+++ b/scripts/catalog-diff.ts
@@ -13,6 +13,7 @@ export type DiffableEntry = {
     specificVersions?: Record<string, string>;
     size?: number;
     tarix?: boolean;
+    bareLatest?: boolean;
 };
 
 export function entryKey(e: { sourceId: string; name: string }): string {
@@ -88,12 +89,13 @@ export async function fetchBaseline(url: string): Promise<DiffableEntry[]> {
     }
     return (data as DiffableEntry[]).flatMap((e) => {
         if (!e || typeof e.name !== "string" || typeof e.sourceId !== "string") return [];
-        // `size`/`tarix` are reused verbatim into output, so reject bad types.
+        // `size`/`tarix`/`bareLatest` are reused verbatim into output, so reject bad types.
         return [
             {
                 ...e,
                 size: typeof e.size === "number" && Number.isFinite(e.size) && e.size >= 0 ? e.size : undefined,
                 tarix: typeof e.tarix === "boolean" ? e.tarix : undefined,
+                bareLatest: typeof e.bareLatest === "boolean" ? e.bareLatest : undefined,
             },
         ];
     });

--- a/scripts/probe-metadata.test.ts
+++ b/scripts/probe-metadata.test.ts
@@ -73,6 +73,50 @@ describe("enrichMetadata", () => {
         expect(stats).toEqual({ reused: 0, probed: 1, failed: 0, skipped: 0 });
     });
 
+    it("falls back to the bare path when a dash versioned artifact is missing", async () => {
+        // Versioned URL 404s (default); only the bare feed file and its tarix exist.
+        const m = { ActionScript: {} };
+        responses.set("https://m.test/feeds/ActionScript.tgz", { status: 200, len: "600" });
+        responses.set("https://m.test/feeds/ActionScript.tgz.tarix", { status: 200, len: "20" });
+        const entries: EnrichableEntry[] = [{ name: "ActionScript", sourceId: "com.kapeli.dash", versions: ["3"] }];
+        const diff = { ...emptyDiff(), changed: ["com.kapeli.dash/ActionScript"] };
+
+        const stats = await enrichMetadata({ entries, diff, baseline: [], manifest: m, mirror: MIRROR });
+
+        expect(entries[0].size).toBe(620);
+        expect(entries[0].tarix).toBe(true);
+        expect(entries[0].bareLatest).toBe(true);
+        expect(stats.probed).toBe(1);
+    });
+
+    it("does not fall back to bare on a transient versioned error", async () => {
+        // Versioned HEAD errors transiently (not a definitive 404); bare exists.
+        // Must stay unset for re-probe, not switch to bare.
+        const m = { ActionScript: {} };
+        throwUrls.add("https://m.test/feeds/zzz/versions/ActionScript/3/ActionScript.tgz");
+        responses.set("https://m.test/feeds/ActionScript.tgz", { status: 200, len: "600" });
+        responses.set("https://m.test/feeds/ActionScript.tgz.tarix", { status: 200, len: "20" });
+        const entries: EnrichableEntry[] = [{ name: "ActionScript", sourceId: "com.kapeli.dash", versions: ["3"] }];
+        const diff = { ...emptyDiff(), changed: ["com.kapeli.dash/ActionScript"] };
+
+        const stats = await enrichMetadata({ entries, diff, baseline: [], manifest: m, mirror: MIRROR, timeoutMs: 50 });
+
+        expect(entries[0].bareLatest).toBeUndefined();
+        expect(entries[0].size).toBeUndefined();
+        expect(stats.failed).toBe(1);
+    });
+
+    it("does not set bareLatest when the versioned artifact resolves normally", async () => {
+        responses.set("https://m.test/feeds/zzz/versions/Go/1.0/Go.tgz", { status: 200, len: "1000" });
+        responses.set("https://m.test/feeds/zzz/versions/Go/1.0/Go.tgz.tarix", { status: 200, len: "50" });
+        const entries: EnrichableEntry[] = [{ name: "Go", sourceId: "com.kapeli.dash", versions: ["1.0"] }];
+        const diff = { ...emptyDiff(), changed: ["com.kapeli.dash/Go"] };
+
+        await enrichMetadata({ entries, diff, baseline: [], manifest, mirror: MIRROR });
+
+        expect(entries[0].bareLatest).toBeUndefined();
+    });
+
     it("dash docset without a tarix index records tarix=false, size=archive", async () => {
         responses.set("https://m.test/feeds/zzz/versions/Go/1.0/Go.tgz", { status: 200, len: "1000" });
         responses.set("https://m.test/feeds/zzz/versions/Go/1.0/Go.tgz.tarix", { status: 302 });

--- a/scripts/probe-metadata.ts
+++ b/scripts/probe-metadata.ts
@@ -17,6 +17,7 @@ export type EnrichableEntry = {
     archive?: string;
     size?: number;
     tarix?: boolean;
+    bareLatest?: boolean;
 };
 
 /** Mirror URL of the archive a `/d/<source>/<name>/latest` request resolves to. */
@@ -33,6 +34,13 @@ export function archiveUrl(entry: EnrichableEntry, mirror: string, manifest: Doc
         default:
             return null;
     }
+}
+
+/** Bare (unversioned) archive URL for a dash docset, or null for other sources. */
+function dashBareUrl(entry: EnrichableEntry, mirror: string, manifest: DocsetManifest): string | null {
+    if (entry.sourceId !== "com.kapeli.dash") return null;
+    const feedName = dashFeedName(entry.name, manifest);
+    return feedName ? dashArchiveUrl(feedName, undefined, mirror) : null;
 }
 
 /**
@@ -115,6 +123,7 @@ export async function enrichMetadata(options: {
         if (base && base.size !== undefined && base.tarix !== undefined) {
             entry.size = base.size;
             entry.tarix = base.tarix;
+            if (base.bareLatest) entry.bareLatest = true;
             reused++;
         } else {
             toProbe.push(entry);
@@ -131,7 +140,23 @@ export async function enrichMetadata(options: {
                 skipped++;
                 return;
             }
-            const archive = await head(url, timeoutMs);
+            let archive = await head(url, timeoutMs);
+            let probeUrl = url;
+            let bareLatest = false;
+            if (archive.kind === "absent") {
+                // A dash docset may advertise a version with no versioned artifact
+                // (only the bare feed file exists). Fall back to the bare path —
+                // only on a definitive miss, never on a transient probe error.
+                const bare = dashBareUrl(entry, mirror, manifest);
+                if (bare && bare !== url) {
+                    const bareHead = await head(bare, timeoutMs);
+                    if (bareHead.kind === "ok") {
+                        archive = bareHead;
+                        probeUrl = bare;
+                        bareLatest = true;
+                    }
+                }
+            }
             if (archive.kind !== "ok" || archive.size === null) {
                 failed++;
                 return;
@@ -141,11 +166,12 @@ export async function enrichMetadata(options: {
             if (!sourceHasTarix(entry.sourceId)) {
                 entry.size = archive.size;
                 entry.tarix = false;
+                if (bareLatest) entry.bareLatest = true;
                 probed++;
                 return;
             }
 
-            const tarix = await head(tarixUrl(url), timeoutMs);
+            const tarix = await head(tarixUrl(probeUrl), timeoutMs);
             if (tarix.kind === "error") {
                 // Unknown tarix state: leave unset so the next build re-probes.
                 failed++;
@@ -153,6 +179,7 @@ export async function enrichMetadata(options: {
             }
             entry.size = archive.size + (tarix.kind === "ok" ? (tarix.size ?? 0) : 0);
             entry.tarix = tarix.kind === "ok";
+            if (bareLatest) entry.bareLatest = true;
             probed++;
         } catch {
             failed++;

--- a/scripts/process-dash-feeds.ts
+++ b/scripts/process-dash-feeds.ts
@@ -25,6 +25,7 @@ export type DocsetInfo = {
     extra?: Record<string, unknown>;
     size?: number;
     tarix?: boolean;
+    bareLatest?: boolean;
 };
 
 function parseVersionList(entry: Record<string, unknown>): {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ type FullEntry = {
     versions: string[];
     archive?: string;
     specificVersions?: Record<string, string>;
+    bareLatest?: boolean;
 };
 
 const dataDir = join(dirname(fileURLToPath(import.meta.url)), "../public/_api/v1");
@@ -62,6 +63,12 @@ export function createApp(
         fullCatalog.filter((d) => d.sourceId === "com.kapeli.cheatsheet").map((d) => d.name),
     );
 
+    // Dash docsets whose latest lives at the bare feed path, not a versioned one
+    // (the feed advertises a version Kapeli never published a versioned artifact for).
+    const dashBareLatest = new Set<string>(
+        fullCatalog.filter((d) => d.sourceId === "com.kapeli.dash" && d.bareLatest).map((d) => d.name),
+    );
+
     const manifest = docsets as Record<string, { source?: string }>;
 
     function buildDashRedirectUrl(
@@ -72,7 +79,8 @@ export function createApp(
     ): string | null {
         const feedName = dashFeedName(docsetId, manifest);
         if (!feedName) return null;
-        const resolvedVersion = version === "latest" ? firstVersion.get(docsetId) : version;
+        const resolvedVersion =
+            version === "latest" ? (dashBareLatest.has(docsetId) ? undefined : firstVersion.get(docsetId)) : version;
         return dashArchiveUrl(feedName, resolvedVersion, mirror);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for "bare latest" variant in Dash docset handling.
  * Enhanced version resolution for "latest" requests on specific docsets.
  * Introduced fallback mechanism for docset archives when standard resolution fails.

* **Tests**
  * Added test cases for bare latest fallback behavior and archive resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->